### PR TITLE
Publish multi-arch Docker images (x86_64 and aarch64)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,7 @@ jobs:
         with:
           name: package
           path: build/
+      - uses: docker/setup-qemu-action@v3
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -176,5 +177,6 @@ jobs:
         with:
           context: .
           file: Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM python:3.14-slim
 # renovate: github-releases depName=typst/typst
 ARG TYPST_VERSION=0.14.2
 
+# Provided by BuildKit (amd64, arm64, …).
+ARG TARGETARCH
+
 WORKDIR /usr/src
 
 COPY build/*.whl .
@@ -10,8 +13,13 @@ COPY tino/gitattributes /etc/gitattributes
 RUN apt-get update && apt-get install -y --no-install-recommends curl git git-lfs xz-utils \
     && pip install --no-cache-dir *.whl \
     && rm -f *.whl \
-    && curl -sSfL https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/typst-x86_64-unknown-linux-musl.tar.xz \
-       | tar -xJ --strip-components=1 -C /usr/local/bin typst-x86_64-unknown-linux-musl/typst \
+    && case "${TARGETARCH}" in \
+         amd64) TYPST_ARCH=x86_64 ;; \
+         arm64) TYPST_ARCH=aarch64 ;; \
+         *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+       esac \
+    && curl -sSfL "https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/typst-${TYPST_ARCH}-unknown-linux-musl.tar.xz" \
+       | tar -xJ --strip-components=1 -C /usr/local/bin "typst-${TYPST_ARCH}-unknown-linux-musl/typst" \
     && git lfs install --system \
     && git config --system core.attributesFile /etc/gitattributes \
     && apt-get purge -y --auto-remove xz-utils \


### PR DESCRIPTION
Currently, published Docker images are restricted to amd64-only because Typst is pinned to x86_64:

https://github.com/confirm/tino/blob/2b3403bac7fa74c36b3b70b34ccd702c04b195a1/Dockerfile#L13-L14

Typst already publishes aarch64 binaries[^1]. This pull request uses `ARG TARGETARCH` in the Dockerfile to use architecture-aware Typst install, and explicitly add platforms `linux/amd64,linux/arm64` to the CI workflow. Everything else should already work on aarch64.

I've tested that this builds on Fedora Asahi Linux 44 on a Linux ARM64 computer, via `docker build` as well as the `make package && make docker-image` commands mentioned in the [developer documentation](https://docs.tinotype.com/development/setup.html#building-the-docker-image).

I'm marking this as a draft pull request until the CI workflow is tested as well.

Closes #11 

[^1]: https://github.com/typst/typst/releases