### PR TITLE
Add review comment threads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ develop = [
     'furo',
     'isort',
     'pycodestyle',
+    'pytest',
     'pylint',
     'Sphinx',
     'sphinx-autobuild',

--- a/tests/test_review_comments.py
+++ b/tests/test_review_comments.py
@@ -1,0 +1,163 @@
+import json
+
+import git
+import pytest
+from fastapi.testclient import TestClient
+
+from tino import config
+from tino.app import create_app
+from tino.dependencies import get_bucket_service, get_collab_manager, get_compiler_service, \
+    get_file_service, get_font_service, get_git_service, get_search_service, \
+    get_review_service, get_template_service
+
+
+@pytest.fixture(autouse=True)
+def app_config(tmp_path, monkeypatch):
+    data_dir = tmp_path / 'data'
+    bucket_dir = data_dir / 'buckets'
+    package_dir = data_dir / 'packages'
+    font_dir = data_dir / 'fonts'
+    for path in (data_dir, bucket_dir, package_dir, font_dir):
+        path.mkdir(parents=True)
+
+    monkeypatch.setattr(config, 'TINO_AUTH_DISABLED', True)
+    monkeypatch.setattr(config, 'TINO_BASE_URL', 'http://localhost:8000')
+    monkeypatch.setattr(config, 'TINO_DATA_DIR', data_dir)
+    monkeypatch.setattr(config, 'TINO_BUCKET_DIR', bucket_dir)
+    monkeypatch.setattr(config, 'TINO_PACKAGE_DIR', package_dir)
+    monkeypatch.setattr(config, 'TINO_FONT_DIR', font_dir)
+
+    for factory in (
+        get_bucket_service,
+        get_collab_manager,
+        get_compiler_service,
+        get_file_service,
+        get_font_service,
+        get_git_service,
+        get_review_service,
+        get_search_service,
+        get_template_service,
+    ):
+        factory.cache_clear()
+
+    yield bucket_dir
+
+    for factory in (
+        get_bucket_service,
+        get_collab_manager,
+        get_compiler_service,
+        get_file_service,
+        get_font_service,
+        get_git_service,
+        get_review_service,
+        get_search_service,
+        get_template_service,
+    ):
+        factory.cache_clear()
+
+
+@pytest.fixture
+def client(app_config):
+    app = create_app()
+    return TestClient(app)
+
+
+def create_bucket_with_file(client, slug='paper', path='main.typ'):
+    response = client.post('/api/buckets', json={'slug': slug, 'name': 'Paper'})
+    assert response.status_code == 201
+
+    response = client.post(
+        f'/api/buckets/{slug}/files',
+        json={'path': path, 'content': 'Hello world\nSecond line\n'},
+    )
+    assert response.status_code == 201
+
+
+def comment_payload(path='main.typ'):
+    return {
+        'anchor': {
+            'column': 1,
+            'end_column': 6,
+            'end_line': 1,
+            'from_offset': 0,
+            'line': 1,
+            'quote': 'Hello',
+            'to_offset': 5,
+        },
+        'body': 'Clarify this opening.',
+        'path': path,
+    }
+
+
+def test_comment_thread_lifecycle(client, app_config):
+    create_bucket_with_file(client)
+
+    response = client.post('/api/buckets/paper/comments', json=comment_payload())
+
+    assert response.status_code == 201
+    created = response.json()
+    thread_id = created['id']
+    assert created['path'] == 'main.typ'
+    assert created['anchor']['quote'] == 'Hello'
+    assert created['status'] == 'open'
+    assert created['created_by'] == 'tino'
+    assert created['messages'][0]['body'] == 'Clarify this opening.'
+
+    response = client.get('/api/buckets/paper/comments?path=main.typ')
+
+    assert response.status_code == 200
+    threads = response.json()
+    assert [thread['id'] for thread in threads] == [thread_id]
+
+    response = client.post(
+        f'/api/buckets/paper/comments/{thread_id}/replies',
+        json={'body': 'Agreed; this needs context.'},
+    )
+
+    assert response.status_code == 200
+    replied = response.json()
+    assert [message['body'] for message in replied['messages']] == [
+        'Clarify this opening.',
+        'Agreed; this needs context.',
+    ]
+
+    response = client.patch(
+        f'/api/buckets/paper/comments/{thread_id}',
+        json={'status': 'resolved'},
+    )
+
+    assert response.status_code == 200
+    resolved = response.json()
+    assert resolved['status'] == 'resolved'
+    assert resolved['resolved_by'] == 'tino'
+    assert resolved['resolved_at']
+
+    response = client.get('/api/buckets/paper/comments?path=main.typ')
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+    response = client.get('/api/buckets/paper/comments?path=main.typ&status=all')
+
+    assert response.status_code == 200
+    assert response.json()[0]['id'] == thread_id
+
+    store = app_config / 'paper' / '.tino' / 'comments.json'
+    data = json.loads(store.read_text())
+    assert data['version'] == 1
+    assert data['threads'][0]['id'] == thread_id
+
+    repo = git.Repo(app_config / 'paper')
+    tracked = repo.git.ls_tree('-r', '--name-only', 'HEAD').splitlines()
+    assert '.tino/comments.json' in tracked
+    assert 'Tino-Meta: true' in repo.head.commit.message
+
+
+def test_comment_rejects_invalid_anchor_path(client):
+    create_bucket_with_file(client)
+
+    payload = comment_payload('../secret.typ')
+    response = client.post('/api/buckets/paper/comments', json=payload)
+
+    assert response.status_code == 400
+    assert response.json()['detail'] == 'Invalid comment path'

--- a/tino/app.py
+++ b/tino/app.py
@@ -17,7 +17,7 @@ from .mcp.server import mcp_asgi_app
 from .middleware import register_middleware
 from .routers import api_keys, buckets, collab
 from .routers import compile as compile_router
-from .routers import events, files, fonts, git, misc, search, templates
+from .routers import events, files, fonts, git, misc, review, search, templates
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +90,7 @@ def create_app() -> FastAPI:
     app.include_router(files.router)
     app.include_router(fonts.router)
     app.include_router(git.router)
+    app.include_router(review.router)
     app.include_router(search.router)
     app.include_router(templates.router)
 

--- a/tino/dependencies.py
+++ b/tino/dependencies.py
@@ -14,6 +14,7 @@ from .services.compiler import CompilerService
 from .services.file import FileService
 from .services.font import FontService
 from .services.git import GitService
+from .services.review import ReviewService
 from .services.search import SearchService
 from .services.template import TemplateService
 
@@ -60,6 +61,12 @@ def get_bucket_service() -> BucketService:
 def get_git_service() -> GitService:
     '''Singleton GitService bound to the configured bucket directory.'''
     return GitService(config.TINO_BUCKET_DIR)
+
+
+@lru_cache
+def get_review_service() -> ReviewService:
+    '''Singleton ReviewService bound to the configured bucket directory.'''
+    return ReviewService(config.TINO_BUCKET_DIR)
 
 
 @lru_cache

--- a/tino/models.py
+++ b/tino/models.py
@@ -1,6 +1,6 @@
 '''Pydantic models for API request/response schemas.'''
 
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field
 
@@ -125,6 +125,58 @@ class RestoreRequest(BaseModel):
     '''Request body for restoring files from a specific commit.'''
     ref: str
     paths: list[str]
+
+
+# ── Review comments ──
+
+
+class ReviewAnchor(BaseModel):
+    '''Source range a review thread is attached to.'''
+    from_offset: int = Field(ge=0)
+    to_offset: int = Field(ge=0)
+    line: int = Field(ge=1)
+    column: int = Field(ge=1)
+    end_line: int = Field(ge=1)
+    end_column: int = Field(ge=1)
+    quote: str = ''
+
+
+class ReviewMessage(BaseModel):
+    '''A single message in a review thread.'''
+    id: str
+    author: str
+    created_at: str
+    body: str
+
+
+class ReviewThread(BaseModel):
+    '''A source-anchored review thread.'''
+    id: str
+    path: str
+    anchor: ReviewAnchor
+    status: Literal['open', 'resolved'] = 'open'
+    created_by: str
+    created_at: str
+    resolved_by: str | None = None
+    resolved_at: str | None = None
+    messages: list[ReviewMessage]
+
+
+class ReviewThreadCreate(BaseModel):
+    '''Request body for creating a review thread.'''
+    path: str
+    anchor: ReviewAnchor
+    body: str = Field(min_length=1)
+
+
+class ReviewReplyCreate(BaseModel):
+    '''Request body for replying to a review thread.'''
+    body: str = Field(min_length=1)
+
+
+class ReviewThreadUpdate(BaseModel):
+    '''Request body for changing review thread state.'''
+    status: Literal['open', 'resolved']
 
 
 # ── Templates ──

--- a/tino/routers/review.py
+++ b/tino/routers/review.py
@@ -1,0 +1,76 @@
+'''REST endpoints for source-anchored review comments.'''
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from ..dependencies import get_review_service, require_editor, require_viewer
+from ..models import ReviewReplyCreate, ReviewThread, ReviewThreadCreate, ReviewThreadUpdate
+from ..services.review import ReviewPathError, ReviewService, ReviewThreadNotFound
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix='/api/buckets/{slug}/comments', tags=['comments'])
+
+
+@router.get('', response_model=list[ReviewThread])
+async def list_comments(
+    slug: str,
+    user=Depends(require_viewer),
+    svc: ReviewService = Depends(get_review_service),
+    path: str | None = Query(None),
+    status: str = Query('open', pattern='^(open|resolved|all)$'),
+):
+    '''List review threads in a bucket, optionally filtered by file path and status.'''
+    logger.debug('Listing review comments for %s/%s (user: %s)', slug, path, user.username)
+    return svc.list(slug, path, status)
+
+
+@router.post('', response_model=ReviewThread, status_code=201)
+async def create_comment(
+    slug: str,
+    body: ReviewThreadCreate,
+    user=Depends(require_editor),
+    svc: ReviewService = Depends(get_review_service),
+):
+    '''Create a review thread anchored to a source range.'''
+    try:
+        return svc.create(slug, body, user)
+    except ReviewPathError as exc:
+        logger.warning(
+            'Comment creation rejected for %s/%s (user: %s)',
+            slug, body.path, user.username,
+        )
+        raise HTTPException(400, 'Invalid comment path') from exc
+
+
+@router.post('/{thread_id}/replies', response_model=ReviewThread)
+async def reply_to_comment(
+    slug: str,
+    thread_id: str,
+    body: ReviewReplyCreate,
+    user=Depends(require_editor),
+    svc: ReviewService = Depends(get_review_service),
+):
+    '''Append a reply to an existing review thread.'''
+    try:
+        return svc.reply(slug, thread_id, body, user)
+    except ReviewThreadNotFound as exc:
+        logger.warning('Reply rejected for missing review thread %s in %s', thread_id, slug)
+        raise HTTPException(404, 'Comment not found') from exc
+
+
+@router.patch('/{thread_id}', response_model=ReviewThread)
+async def update_comment(
+    slug: str,
+    thread_id: str,
+    body: ReviewThreadUpdate,
+    user=Depends(require_editor),
+    svc: ReviewService = Depends(get_review_service),
+):
+    '''Resolve or reopen a review thread.'''
+    try:
+        return svc.update(slug, thread_id, body, user)
+    except ReviewThreadNotFound as exc:
+        logger.warning('Update rejected for missing review thread %s in %s', thread_id, slug)
+        raise HTTPException(404, 'Comment not found') from exc

--- a/tino/services/review.py
+++ b/tino/services/review.py
@@ -1,0 +1,185 @@
+'''Review comment storage service for source-anchored discussion threads.'''
+
+import json
+import logging
+import threading
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from uuid import uuid4
+
+import git
+
+from ..models import ReviewMessage, ReviewReplyCreate, ReviewThread, ReviewThreadCreate, \
+    ReviewThreadUpdate, User
+
+logger = logging.getLogger(__name__)
+
+STORE_RELATIVE = '.tino/comments.json'
+
+
+class ReviewPathError(ValueError):
+    '''Raised when a review thread targets an invalid or missing source path.'''
+
+
+class ReviewThreadNotFound(KeyError):
+    '''Raised when a review thread id is not present in the bucket store.'''
+
+
+class ReviewService:
+    '''CRUD operations for hidden, git-backed review comment metadata.'''
+
+    def __init__(self, data_dir: Path):
+        self.data_dir = data_dir
+        self._slug_locks: dict[str, threading.Lock] = {}
+        self._locks_guard = threading.Lock()
+
+    def _slug_lock(self, slug: str) -> threading.Lock:
+        '''Return a per-slug lock for read-modify-write operations.'''
+        with self._locks_guard:
+            lock = self._slug_locks.get(slug)
+            if lock is None:
+                lock = threading.Lock()
+                self._slug_locks[slug] = lock
+            return lock
+
+    def _bucket_path(self, slug: str) -> Path:
+        return self.data_dir / slug
+
+    def _store_path(self, slug: str) -> Path:
+        return self._bucket_path(slug) / STORE_RELATIVE
+
+    @staticmethod
+    def _empty_store() -> dict:
+        return {'threads': [], 'version': 1}
+
+    def _read_store(self, slug: str) -> dict:
+        store = self._store_path(slug)
+        if not store.exists():
+            return self._empty_store()
+        data = json.loads(store.read_text(encoding='utf-8'))
+        data.setdefault('version', 1)
+        data.setdefault('threads', [])
+        return data
+
+    def _write_store(self, slug: str, data: dict, user: User) -> None:
+        root = self._bucket_path(slug)
+        store = self._store_path(slug)
+        store.parent.mkdir(parents=True, exist_ok=True)
+        store.write_text(
+            json.dumps(data, indent=2, sort_keys=True) + '\n',
+            encoding='utf-8',
+        )
+        self._commit_metadata(root, user)
+
+    @staticmethod
+    def _commit_metadata(root: Path, user: User) -> None:
+        repo = git.Repo(root)
+        try:
+            repo.index.add([STORE_RELATIVE])
+            if not repo.is_dirty(index=True, working_tree=False, untracked_files=True):
+                return
+            actor = git.Actor(user.username, user.email or f'{user.username}@tino')
+            repo.index.commit(
+                'Update review comments\n\nTino-Meta: true',
+                author=actor,
+                committer=actor,
+            )
+        finally:
+            repo.close()
+
+    def _validate_path(self, slug: str, path: str) -> None:
+        pure = PurePosixPath(path)
+        if (
+            not path
+            or pure.is_absolute()
+            or any(part in {'', '..'} or part.startswith('.') for part in pure.parts)
+        ):
+            raise ReviewPathError(path)
+
+        root = self._bucket_path(slug).resolve()
+        target = (root / path).resolve()
+        if not target.is_relative_to(root) or not target.is_file():
+            raise ReviewPathError(path)
+
+    @staticmethod
+    def _now() -> str:
+        return datetime.now(timezone.utc).isoformat()
+
+    @staticmethod
+    def _message(body: str, user: User) -> ReviewMessage:
+        return ReviewMessage(
+            id=uuid4().hex,
+            author=user.username,
+            body=body.strip(),
+            created_at=ReviewService._now(),
+        )
+
+    @staticmethod
+    def _find(data: dict, thread_id: str) -> dict:
+        for thread in data['threads']:
+            if thread['id'] == thread_id:
+                return thread
+        raise ReviewThreadNotFound(thread_id)
+
+    def list(
+        self, slug: str, path: str | None = None,
+        status: str = 'open',
+    ) -> list[ReviewThread]:
+        '''List review threads, optionally filtered by source path and status.'''
+        data = self._read_store(slug)
+        threads = data['threads']
+        if path is not None:
+            threads = [thread for thread in threads if thread['path'] == path]
+        if status != 'all':
+            threads = [thread for thread in threads if thread['status'] == status]
+        return [ReviewThread(**thread) for thread in threads]
+
+    def create(self, slug: str, body: ReviewThreadCreate, user: User) -> ReviewThread:
+        '''Create a new review thread anchored to an existing visible source file.'''
+        self._validate_path(slug, body.path)
+        with self._slug_lock(slug):
+            data = self._read_store(slug)
+            thread = ReviewThread(
+                id=uuid4().hex,
+                path=body.path,
+                anchor=body.anchor,
+                created_by=user.username,
+                created_at=self._now(),
+                messages=[self._message(body.body, user)],
+            )
+            data['threads'].append(thread.model_dump())
+            self._write_store(slug, data, user)
+            logger.info('Created review thread %s in %s/%s', thread.id, slug, body.path)
+            return thread
+
+    def reply(
+        self, slug: str, thread_id: str,
+        body: ReviewReplyCreate, user: User,
+    ) -> ReviewThread:
+        '''Append a reply to an existing review thread.'''
+        with self._slug_lock(slug):
+            data = self._read_store(slug)
+            thread = self._find(data, thread_id)
+            thread['messages'].append(self._message(body.body, user).model_dump())
+            self._write_store(slug, data, user)
+            logger.info('Replied to review thread %s in %s', thread_id, slug)
+            return ReviewThread(**thread)
+
+    def update(
+        self, slug: str, thread_id: str,
+        body: ReviewThreadUpdate, user: User,
+    ) -> ReviewThread:
+        '''Change a review thread's open/resolved status.'''
+        with self._slug_lock(slug):
+            data = self._read_store(slug)
+            thread = self._find(data, thread_id)
+            thread['status'] = body.status
+            if body.status == 'resolved':
+                thread['resolved_by'] = user.username
+                thread['resolved_at'] = self._now()
+            else:
+                thread['resolved_by'] = None
+                thread['resolved_at'] = None
+            self._write_store(slug, data, user)
+            logger.info('Updated review thread %s in %s to %s', thread_id, slug, body.status)
+            return ReviewThread(**thread)

--- a/tino/static/css/styles.css
+++ b/tino/static/css/styles.css
@@ -711,6 +711,16 @@ html, body {
   border-right: 1px solid var(--border);
 }
 
+.editor .cm-review-mark {
+  background: color-mix(in srgb, var(--accent) 28%, transparent);
+  border-bottom: 1px solid var(--accent);
+  cursor: pointer;
+}
+
+.editor .cm-review-line {
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+}
+
 /* stylelint-disable selector-class-pattern, no-descending-specificity -- upstream CodeMirror class names */
 
 .editor .cm-activeLine,
@@ -995,6 +1005,197 @@ html, body {
 
 .status-btn:hover {
   color: var(--accent);
+}
+
+/* ── Review comments ── */
+
+.review-panel {
+  display: flex;
+  flex-direction: column;
+  width: 320px;
+  min-width: 260px;
+  max-width: 42%;
+  background: var(--bg-secondary);
+  border-left: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.review-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: var(--panel-header-height);
+  padding: 0 10px 0 12px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.review-header-actions {
+  display: flex;
+  gap: 2px;
+}
+
+#btn-review-resolved.active {
+  color: var(--accent);
+  background: var(--bg-hover);
+}
+
+.review-compose {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-primary);
+  flex-shrink: 0;
+}
+
+.review-anchor-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--accent);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.review-compose-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.review-list {
+  flex: 1;
+  min-height: 0;
+  margin: 0;
+  padding: 8px;
+  list-style: none;
+  overflow-y: auto;
+}
+
+.review-empty {
+  padding: 20px 12px;
+  color: var(--text-muted);
+  font-size: 12px;
+  text-align: center;
+}
+
+.review-thread {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 8px;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-tertiary);
+  cursor: pointer;
+}
+
+.review-thread:hover {
+  border-color: var(--border-light);
+}
+
+.review-resolved {
+  opacity: 0.72;
+}
+
+.review-thread-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.review-anchor {
+  flex: 1;
+  min-width: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.review-status {
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: var(--bg-hover);
+  color: var(--text-muted);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+.review-actions {
+  display: flex;
+  flex-shrink: 0;
+}
+
+.review-action-btn {
+  padding: 2px 6px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.review-action-btn:hover {
+  color: var(--text-primary);
+  border-color: var(--accent);
+}
+
+.review-quote {
+  margin: 0;
+  padding: 6px 8px;
+  border-left: 2px solid var(--accent);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.review-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.review-message-meta {
+  margin-bottom: 2px;
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.review-message-body {
+  color: var(--text-primary);
+  font-size: 12px;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.review-reply {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.review-reply-button {
+  align-self: flex-end;
 }
 
 /* ── Preview ── */

--- a/tino/static/index.html
+++ b/tino/static/index.html
@@ -35,6 +35,10 @@
         <span class="material-symbols-outlined">history</span>
         History
       </button>
+      <button class="toolbar-btn hidden" id="btn-review" title="Review comments">
+        <span class="material-symbols-outlined">rate_review</span>
+        Review
+      </button>
       <button class="toolbar-btn hidden" id="btn-download" title="Download bucket as ZIP">
         <span class="material-symbols-outlined">download</span>
         Download
@@ -144,10 +148,36 @@
         <button class="fmt-btn active" data-action="wrap" title="Word wrap">
           <span class="material-symbols-outlined">wrap_text</span>
         </button>
+        <span class="fmt-sep"></span>
+        <button class="fmt-btn" data-action="comment" title="Add comment">
+          <span class="material-symbols-outlined">add_comment</span>
+        </button>
       </div>
       <div class="editor-wrap">
         <div class="editor" id="editor"></div>
         <div class="binary-preview hidden" id="binary-preview"></div>
+        <aside class="review-panel hidden" id="review-panel">
+          <div class="review-header">
+            <span>Review</span>
+            <div class="review-header-actions">
+              <button class="icon-btn" id="btn-review-resolved" title="Show resolved comments">
+                <span class="material-symbols-outlined">done_all</span>
+              </button>
+              <button class="icon-btn" id="btn-review-close" title="Close review panel">
+                <span class="material-symbols-outlined">close</span>
+              </button>
+            </div>
+          </div>
+          <div class="review-compose hidden" id="review-compose">
+            <div class="review-anchor-label" id="review-compose-anchor"></div>
+            <textarea class="form-input" id="review-compose-body" rows="4" placeholder="Write a comment..."></textarea>
+            <div class="review-compose-actions">
+              <button class="btn btn-secondary btn-small" id="btn-review-compose-cancel">Cancel</button>
+              <button class="btn btn-primary btn-small" id="btn-review-compose-submit">Comment</button>
+            </div>
+          </div>
+          <ul class="review-list" id="review-list"></ul>
+        </aside>
       </div>
       <div class="status-bar">
         <span id="cursor-pos">Ln 1, Col 1</span>

--- a/tino/static/js/api.js
+++ b/tino/static/js/api.js
@@ -160,6 +160,48 @@ export class TinoAPI extends GitAPI {
     return this._fetch(`/api/search?${params}`)
   }
 
+  // ── Review comments ──
+
+  /** List review comment threads. */
+
+  listComments(slug, path, status) {
+    const params = new URLSearchParams()
+    if (path)
+      params.set('path', path)
+    if (status)
+      params.set('status', status)
+    const qs = params.size ? `?${params}` : ''
+    return this._fetch(`${bucketPath(slug)}/comments${qs}`)
+  }
+
+  /** Create a source-anchored review comment thread. */
+
+  createComment(slug, path, anchor, body) {
+    return this._json(
+      'POST', `${bucketPath(slug)}/comments`, { anchor, body, path },
+    )
+  }
+
+  /** Reply to an existing review comment thread. */
+
+  replyToComment(slug, threadId, body) {
+    return this._json(
+      'POST',
+      `${bucketPath(slug)}/comments/${encodeURIComponent(threadId)}/replies`,
+      { body },
+    )
+  }
+
+  /** Resolve or reopen a review comment thread. */
+
+  updateComment(slug, threadId, status) {
+    return this._json(
+      'PATCH',
+      `${bucketPath(slug)}/comments/${encodeURIComponent(threadId)}`,
+      { status },
+    )
+  }
+
   // ── Compile ──
 
   compile(slug, path) {

--- a/tino/static/js/app.js
+++ b/tino/static/js/app.js
@@ -8,6 +8,7 @@ import { FontManager } from './font-manager.js'
 import { GitManager } from './git-manager.js'
 import { PanelResize } from './panel-resize.js'
 import { PreviewManager } from './preview-manager.js'
+import { ReviewManager } from './review-manager.js'
 import { SearchModal } from './search-modal.js'
 import { TemplatePicker } from './template-picker.js'
 import { TinoAPI } from './api.js'
@@ -76,6 +77,8 @@ class TinoApp {
     this.editor = new EditorManager(this)
     this.fileTree = new FileTree(this)
     this.git = new GitManager(this)
+    this.review = new ReviewManager(this)
+    this.review.bind()
     this.panelResize = new PanelResize()
     this.preview = new PreviewManager(this)
     this._initDialogs()
@@ -221,6 +224,7 @@ class TinoApp {
     this.editor.resetState()
     this._applyRoleVisibility()
     this.fileTree.clear()
+    this.review.clear()
     this.preview.update()
     writeRoute(null, null)
   }
@@ -247,6 +251,7 @@ class TinoApp {
     await this.git.loadStatus()
     await this.fileTree.loadFiles()
     this.editor.reconcileTabs(this.fileTree.filePaths)
+    await this.review.loadForCurrentFile()
   }
 
   /** Show or hide editor actions based on the user's role in the current bucket. */
@@ -262,6 +267,7 @@ class TinoApp {
       'btn-download': canView,
       'btn-history': canView,
       'btn-history-restore': canEdit,
+      'btn-review': canView,
       'btn-save': canEdit,
       'tree-new': canEdit,
     }))

--- a/tino/static/js/codemirror-editor.js
+++ b/tino/static/js/codemirror-editor.js
@@ -25,6 +25,7 @@ import {
 } from './vendor/codemirror.js'
 import { typst, typstKeymap } from './codemirror-typst.js'
 import { SINGLE_ITEM } from './constants.js'
+import { reviewExtensions } from './codemirror-review.js'
 
 /**
  * Editor controller around a CodeMirror 6 EditorView. Owns the view, its
@@ -37,9 +38,7 @@ import { SINGLE_ITEM } from './constants.js'
  */
 
 const _programmatic = Annotation.define()
-
 const _noop = () => null
-
 export class CodeMirrorEditor {
 
   /**
@@ -141,6 +140,7 @@ export class CodeMirrorEditor {
         ]),
         this._editable.of(EditorView.editable.of(true)),
         this._placeholder.of(placeholder('')),
+        reviewExtensions,
         EditorView.updateListener.of(update => this._onUpdate(update)),
       ],
     })

--- a/tino/static/js/codemirror-entry.js
+++ b/tino/static/js/codemirror-entry.js
@@ -8,8 +8,9 @@
  * the same module instances (a second copy would break facet/type identity).
  */
 
-export { Annotation, Compartment, EditorState } from '@codemirror/state'
+export { Annotation, Compartment, EditorState, StateEffect, StateField } from '@codemirror/state'
 export {
+  Decoration,
   EditorView,
   drawSelection,
   keymap,

--- a/tino/static/js/codemirror-review.js
+++ b/tino/static/js/codemirror-review.js
@@ -1,0 +1,69 @@
+import {
+  Decoration,
+  EditorView,
+  StateEffect,
+  StateField,
+} from './vendor/codemirror.js'
+
+const OPEN_STATUS = 'open'
+
+export const setReviewDecorations = StateEffect.define()
+
+export const reviewExtensions = StateField.define({
+  create: () => Decoration.set([]),
+  provide: field => EditorView.decorations.from(field),
+  update(value, tr) {
+    const effect = tr.effects.find(item => item.is(setReviewDecorations))
+    return effect ? effect.value : value.map(tr.changes)
+  },
+})
+
+const clampRange = (state, anchor) => {
+  const max = state.doc.length
+  const from = Math.max(0, Math.min(anchor.from_offset, max))
+  const to = Math.max(from, Math.min(anchor.to_offset, max))
+  return { from, to }
+}
+
+const markerFor = (state, thread) => {
+  const { from, to } = clampRange(state, thread.anchor)
+  if (to > from) {
+    return Decoration.mark({
+      attributes: { 'data-review-id': thread.id },
+      class: 'cm-review-mark',
+    }).range(from, to)
+  }
+  const line = state.doc.lineAt(from)
+  return Decoration.line({
+    attributes: { 'data-review-id': thread.id },
+    class: 'cm-review-line',
+  }).range(line.from)
+}
+
+export const buildReviewDecorations = (state, threads) => Decoration.set(
+  (threads || [])
+    .filter(thread => thread.status === OPEN_STATUS)
+    .map(thread => markerFor(state, thread)),
+  true,
+)
+
+export const setReviewThreads = (view, threads) => {
+  view.dispatch({
+    effects: setReviewDecorations.of(
+      buildReviewDecorations(view.state, threads),
+    ),
+  })
+}
+
+export const selectReviewRange = (view, from, to) => {
+  const max = view.state.doc.length
+  const start = Math.max(0, Math.min(from, max))
+  const end = Math.max(start, Math.min(to, max))
+  // eslint-disable-next-line id-length -- CodeMirror's scrollIntoView axis key
+  const scroll = EditorView.scrollIntoView(start, { y: 'center' })
+  view.dispatch({
+    effects: scroll,
+    selection: { anchor: start, head: end },
+  })
+  view.focus()
+}

--- a/tino/static/js/editor-manager.js
+++ b/tino/static/js/editor-manager.js
@@ -47,7 +47,6 @@ export class EditorManager {
     this._activateTab(path, loaded)
     await this.app.preview.update()
   }
-
   _flushPendingSave() {
     if (this._saveTimer) {
       clearTimeout(this._saveTimer)
@@ -55,7 +54,6 @@ export class EditorManager {
       this.saveCurrentFile()
     }
   }
-
   _activateTab(path, loaded) {
     this.app.currentFile = path
     this.app.els.editor.setPlaceholder('')
@@ -73,6 +71,7 @@ export class EditorManager {
       this.app.els.editor.setCursor(pos.line, pos.col)
     this._refreshEditorUi()
     this._persistOpenState(path)
+    this.app.review.loadForCurrentFile()
   }
 
   /**
@@ -115,7 +114,6 @@ export class EditorManager {
     this.app.els.editor.setHidden(false)
     this.toolbar[canEdit ? 'show' : 'hide']()
   }
-
   _refreshEditorUi() {
     this.input.renderTabs()
     this.input.highlightFileItem(this.app.currentFile)
@@ -209,6 +207,7 @@ export class EditorManager {
     this.app.els.editor.setEditable(false)
     this.app.els.editor.setPlaceholder(PLACEHOLDER)
     this.input.updateStatusBar()
+    this.app.review.clear()
     writeRoute(this.app.bucket, null)
   }
 
@@ -279,6 +278,7 @@ export class EditorManager {
     this.app.els.editor.setEditable(false)
     this.app.els.editor.setPlaceholder(PLACEHOLDER)
     this.app.els.tabBar.innerHTML = ''
+    this.app.review.clear()
   }
 
   _clearOpenState() {

--- a/tino/static/js/editor-toolbar.js
+++ b/tino/static/js/editor-toolbar.js
@@ -70,6 +70,7 @@ export class EditorToolbar {
       case 'math': this._wrap('$'); break
       case 'table': this._insertTable(); break
       case 'wrap': this._toggleWrap(); break
+      case 'comment': this.app.review.openComposerFromSelection(); break
       default: break
     }
   }

--- a/tino/static/js/review-manager.js
+++ b/tino/static/js/review-manager.js
@@ -1,0 +1,220 @@
+import { el, reviewThreadNode } from './review-nodes.js'
+import { selectReviewRange, setReviewThreads } from './codemirror-review.js'
+import { SINGLE_ITEM } from './constants.js'
+
+const OPEN_STATUS = 'open'
+const MAX_QUOTE_LENGTH = 500
+
+export class ReviewManager {
+
+  constructor(app) {
+    this.app = app
+    this.threads = []
+    this.pendingAnchor = null
+    this.showResolved = false
+    this.els = {
+      anchor: document.getElementById('review-compose-anchor'),
+      body: document.getElementById('review-compose-body'),
+      compose: document.getElementById('review-compose'),
+      list: document.getElementById('review-list'),
+      panel: document.getElementById('review-panel'),
+      resolved: document.getElementById('btn-review-resolved'),
+    }
+  }
+
+  bind() {
+    document.getElementById('btn-review')
+      .addEventListener('click', () => this.toggle())
+    document.getElementById('btn-review-close')
+      .addEventListener('click', () => this.toggle(false))
+    document.getElementById('btn-review-compose-cancel')
+      .addEventListener('click', () => this.cancelComposer())
+    document.getElementById('btn-review-compose-submit')
+      .addEventListener('click', () => this.submitComment())
+    this.els.resolved.addEventListener('click', () => this.toggleResolved())
+    this.els.list.addEventListener('click', evt => this._onListClick(evt))
+  }
+
+  get canEdit() {
+    return ['editor', 'committer'].includes(this.app.bucketRole)
+  }
+
+  toggle(force) {
+    const next = typeof force === 'boolean' ? force : this.els.panel.classList.contains('hidden')
+    this.els.panel.classList.toggle('hidden', !next)
+    document.getElementById('btn-review').classList.toggle('active', next)
+    if (next)
+      this.loadForCurrentFile()
+  }
+
+  async toggleResolved() {
+    this.showResolved = !this.showResolved
+    this.els.resolved.classList.toggle('active', this.showResolved)
+    await this.loadForCurrentFile()
+  }
+
+  clear() {
+    this.threads = []
+    this.pendingAnchor = null
+    setReviewThreads(this.app.els.editor.view, [])
+    this._render()
+  }
+
+  async loadForCurrentFile() {
+    if (!this.app.bucket || !this.app.currentFile || this.app.els.editor.hidden) {
+      this.clear()
+      return
+    }
+    const status = this.showResolved ? 'all' : OPEN_STATUS
+    this.threads = await this.app.api.listComments(
+      this.app.bucket, this.app.currentFile, status,
+    )
+    setReviewThreads(this.app.els.editor.view, this.threads)
+    this._render()
+  }
+
+  openComposerFromSelection() {
+    if (!this._canStartComment())
+      return
+    this._showComposer(this._anchorFromSelection())
+  }
+
+  _canStartComment() {
+    if (!this.canEdit) {
+      this.app.toast.error('Editor role required to comment')
+      return false
+    }
+    if (!this.app.currentFile || this.app.els.editor.hidden) {
+      this.app.toast.error('Open a text file before adding a comment')
+      return false
+    }
+    return true
+  }
+
+  _showComposer(anchor) {
+    this.pendingAnchor = anchor
+    this.els.anchor.textContent = this._anchorText(anchor)
+    this.els.body.value = ''
+    this.els.compose.classList.remove('hidden')
+    this.toggle(true)
+    this.els.body.focus()
+  }
+
+  cancelComposer() {
+    this.pendingAnchor = null
+    this.els.body.value = ''
+    this.els.compose.classList.add('hidden')
+  }
+
+  async submitComment() {
+    const body = this.els.body.value.trim()
+    if (!body || !this.pendingAnchor)
+      return
+    const thread = await this.app.api.createComment(
+      this.app.bucket, this.app.currentFile, this.pendingAnchor, body,
+    )
+    this.cancelComposer()
+    await this.loadForCurrentFile()
+    this.jumpToThread(thread.id)
+  }
+
+  jumpToThread(threadId) {
+    const thread = this.threads.find(item => item.id === threadId)
+    if (!thread)
+      return
+    selectReviewRange(
+      this.app.els.editor.view,
+      thread.anchor.from_offset,
+      thread.anchor.to_offset,
+    )
+  }
+
+  async _onListClick(evt) {
+    const button = evt.target.closest('[data-review-action]')
+    const item = evt.target.closest('.review-thread')
+    if (!item)
+      return
+    const threadId = item.dataset.thread
+    if (!button) {
+      if (evt.target.closest('input, textarea, select, label'))
+        return
+      this.jumpToThread(threadId)
+      return
+    }
+    const action = button.dataset.reviewAction
+    if (action === 'jump')
+      this.jumpToThread(threadId)
+    else if (action === 'resolve')
+      await this._updateStatus(threadId, 'resolved')
+    else if (action === 'reopen')
+      await this._updateStatus(threadId, OPEN_STATUS)
+    else if (action === 'reply')
+      await this._reply(threadId, item)
+  }
+
+  async _updateStatus(threadId, status) {
+    await this.app.api.updateComment(this.app.bucket, threadId, status)
+    await this.loadForCurrentFile()
+  }
+
+  async _reply(threadId, item) {
+    const input = item.querySelector('.review-reply-input')
+    const body = input.value.trim()
+    if (!body)
+      return
+    await this.app.api.replyToComment(this.app.bucket, threadId, body)
+    input.value = ''
+    await this.loadForCurrentFile()
+  }
+
+  _anchorFromSelection() {
+    const ed = this.app.els.editor
+    const { from, to } = ed.selection
+    const start = Math.min(from, to)
+    const end = Math.max(from, to)
+    const { doc } = ed.view.state
+    const startLine = doc.lineAt(start)
+    const endLine = doc.lineAt(end)
+    const quote = ReviewManager._quoteFor(ed.content, doc, start, end)
+    return {
+      column: start - startLine.from + SINGLE_ITEM,
+      end_column: end - endLine.from + SINGLE_ITEM,
+      end_line: endLine.number,
+      from_offset: start,
+      line: startLine.number,
+      quote,
+      to_offset: end,
+    }
+  }
+
+  static _quoteFor(content, doc, start, end) {
+    if (end > start)
+      return content.slice(start, end).slice(0, MAX_QUOTE_LENGTH)
+    return doc.lineAt(start).text.trim().slice(0, MAX_QUOTE_LENGTH)
+  }
+
+  _anchorText(anchor) {
+    const path = this.app.currentFile
+    if (anchor.line === anchor.end_line && anchor.column === anchor.end_column)
+      return `${path}:${anchor.line}:${anchor.column}`
+    if (anchor.line === anchor.end_line)
+      return `${path}:${anchor.line}:${anchor.column}-${anchor.end_column}`
+    return `${path}:${anchor.line}:${anchor.column}-${anchor.end_line}:${anchor.end_column}`
+  }
+
+  _render() {
+    this.els.list.replaceChildren()
+    if (!this.app.currentFile) {
+      this.els.list.appendChild(el('li', 'review-empty', 'Open a text file to review.'))
+      return
+    }
+    if (!this.threads.length) {
+      const msg = this.showResolved ? 'No comments for this file.' : 'No open comments.'
+      this.els.list.appendChild(el('li', 'review-empty', msg))
+      return
+    }
+    for (const thread of this.threads)
+      this.els.list.appendChild(reviewThreadNode(thread, this.canEdit, OPEN_STATUS))
+  }
+
+}

--- a/tino/static/js/review-nodes.js
+++ b/tino/static/js/review-nodes.js
@@ -1,0 +1,77 @@
+export const el = function el(tag, className, text = null) {
+  const node = document.createElement(tag)
+  if (className)
+    node.className = className
+  if (text !== null)
+    node.textContent = text
+  return node
+}
+
+const formatWhen = value => value ? new Date(value).toLocaleString() : ''
+
+const messageNode = function messageNode(message) {
+  const node = el('div', 'review-message')
+  const meta = el(
+    'div', 'review-message-meta', `${message.author} · ${formatWhen(message.created_at)}`,
+  )
+  node.append(meta, el('div', 'review-message-body', message.body))
+  return node
+}
+
+const anchorButton = function anchorButton(thread) {
+  const text = `${thread.path}:${thread.anchor.line}:${thread.anchor.column}`
+  const button = el('button', 'review-anchor', text)
+  button.type = 'button'
+  button.dataset.reviewAction = 'jump'
+  return button
+}
+
+const threadActions = function threadActions(thread, openStatus) {
+  const node = el('div', 'review-actions')
+  const label = thread.status === openStatus ? 'Resolve' : 'Reopen'
+  const action = thread.status === openStatus ? 'resolve' : 'reopen'
+  const button = el('button', 'review-action-btn', label)
+  button.type = 'button'
+  button.dataset.reviewAction = action
+  node.appendChild(button)
+  return node
+}
+
+const threadHeader = function threadHeader(thread, canEdit, openStatus) {
+  const header = el('div', 'review-thread-header')
+  header.append(anchorButton(thread), el('span', 'review-status', thread.status))
+  if (canEdit)
+    header.appendChild(threadActions(thread, openStatus))
+  return header
+}
+
+const messagesNode = function messagesNode(thread) {
+  const messages = el('div', 'review-messages')
+  for (const message of thread.messages)
+    messages.appendChild(messageNode(message))
+  return messages
+}
+
+const replyNode = function replyNode() {
+  const reply = el('div', 'review-reply')
+  const input = el('textarea', 'form-input review-reply-input')
+  const button = el('button', 'btn btn-secondary btn-small review-reply-button', 'Reply')
+  input.rows = 2
+  input.placeholder = 'Reply...'
+  button.type = 'button'
+  button.dataset.reviewAction = 'reply'
+  reply.append(input, button)
+  return reply
+}
+
+export const reviewThreadNode = function reviewThreadNode(thread, canEdit, openStatus) {
+  const item = el('li', `review-thread review-${thread.status}`)
+  item.dataset.thread = thread.id
+  item.appendChild(threadHeader(thread, canEdit, openStatus))
+  if (thread.anchor.quote)
+    item.appendChild(el('blockquote', 'review-quote', thread.anchor.quote))
+  item.appendChild(messagesNode(thread))
+  if (canEdit && thread.status === openStatus)
+    item.appendChild(replyNode())
+  return item
+}


### PR DESCRIPTION
## Summary

- Add a git-backed review comment store under `.tino/comments.json` for source-anchored discussion threads.
- Add comment list/create/reply/resolve API endpoints and Pydantic models.
- Add the frontend review panel, comment composer, CodeMirror source decorations, and review toolbar actions.
- Add focused API tests for the comment lifecycle and invalid anchor paths.

## Notes

This PR keeps the scope to base review-thread functionality. It does not include local-auth changes, deployment configuration, or the follow-up targeted-reply behavior.

## Validation

- `uv run pytest tests/test_review_comments.py -q`
- `PATH="$PWD/.venv/bin:$PATH" make test-pycodestyle`
- `make test-eslint`
- `make test-stylelint`
- `npm run build`
