### PR TITLE
FIX: Explicitly request groups scope and fetch userinfo

### DIFF
--- a/docs/operations/deployment.rst
+++ b/docs/operations/deployment.rst
@@ -202,7 +202,7 @@ Register a new client (application) with your OIDC provider:
 
        https://tino.example.com/login
 
-4. Ensure the following **scopes** are enabled: ``openid``, ``email``, ``profile``.
+4. Ensure the following **scopes** are enabled: ``openid``, ``email``, ``groups``, ``profile``.
 5. Make sure the **ID token** includes a claim with the user's group memberships
    (see :attr:`TINO_OIDC_GROUPS_CLAIM <tino.config.TINO_OIDC_GROUPS_CLAIM>`).
 6. Make sure a user matches an admin group (see :attr:`TINO_ADMIN_GROUPS <tino.config.TINO_ADMIN_GROUPS>`)

--- a/tino/auth.py
+++ b/tino/auth.py
@@ -40,7 +40,7 @@ async def setup_oauth():
         client_id=config.TINO_OIDC_CLIENT_ID,
         client_secret=config.TINO_OIDC_CLIENT_SECRET,
         server_metadata_url=config.TINO_OIDC_DISCOVERY_URL,
-        client_kwargs={'scope': 'openid email profile'},
+        client_kwargs={'scope': 'openid email profile groups'},
     )
     await oauth.oidc.load_server_metadata()
     logger.info('OIDC provider ready (client_id=%s)', config.TINO_OIDC_CLIENT_ID)
@@ -147,7 +147,7 @@ async def login(request: Request):
 async def callback(request: Request):
     '''Handle the OIDC callback, exchange code for tokens, and create a session.'''
     token    = await oauth.oidc.authorize_access_token(request)
-    userinfo = token.get('userinfo', {})
+    userinfo = await oauth.oidc.userinfo(token=token)
 
     if not userinfo:
         raise HTTPException(400, 'No user info in token response')

--- a/tino/routers/misc.py
+++ b/tino/routers/misc.py
@@ -118,7 +118,7 @@ async def oauth_protected_resource():
     payload = {
         'resource': config.TINO_BASE_URL,
         'authorization_servers': [config.TINO_BASE_URL],
-        'scopes_supported': ['openid', 'profile', 'email'],
+        'scopes_supported': ['openid', 'profile', 'email', 'groups'],
         'bearer_methods_supported': ['header'],
     }
     logger.info('Protected resource metadata: resource=%s, AS=self',


### PR DESCRIPTION
I was trying to use TINO with Authelia as an OIDC provider and could not login correctly. When logged in, the UI displayed my sub UUID instead of my actual username, and my groups were returning as empty (even though they were correctly configured in Authelia).

Previously, TINO assumed the identity provider would automatically inject the groups and preferred_username claims into the initial ID token. Authelia requires the groups scope to be explicitly requested, and a separate trip to the /userinfo endpoint to fetch the full profile payload.

I managed to fix the issue with this patch by:

Explicitly requesting the groups scope in the authlib client and MCP discovery metadata.

Making a direct call to oauth.oidc.userinfo() in the callback to reliably fetch the complete profile.

Let me know if you would like me to adjust anything!