### PR TITLE
FIX: Make OIDC UserInfo endpoint optional

### DIFF
--- a/docs/development/adr/07-oidc.rst
+++ b/docs/development/adr/07-oidc.rst
@@ -14,7 +14,7 @@ Decision
 
 TINO delegates authentication entirely to an external `OpenID Connect <https://openid.net/developers/how-connect-works/>`_ provider (e.g. `Keycloak <https://www.keycloak.org/>`_).
 The OIDC callback establishes a signed server-side session cookie.
-Group claims from the ID token drive :ref:`bucket-level access control <Buckets>`.
+Group claims from the ID token or the UserInfo endpoint drive :ref:`bucket-level access control <Buckets>`.
 
 Authentication can be disabled entirely via ``TINO_AUTH_DISABLED`` for local development or trusted internal deployments.
 

--- a/docs/operations/deployment.rst
+++ b/docs/operations/deployment.rst
@@ -203,8 +203,9 @@ Register a new client (application) with your OIDC provider:
        https://tino.example.com/login
 
 4. Ensure the following **scopes** are enabled: ``openid``, ``email``, ``groups``, ``profile``.
-5. Make sure the **ID token** includes a claim with the user's group memberships
-   (see :attr:`TINO_OIDC_GROUPS_CLAIM <tino.config.TINO_OIDC_GROUPS_CLAIM>`).
+5. Make sure the user's group memberships are exposed under a claim (see
+   :attr:`TINO_OIDC_GROUPS_CLAIM <tino.config.TINO_OIDC_GROUPS_CLAIM>`), either in
+   the **ID token** or from the **UserInfo endpoint** (TINO will merge them).
 6. Make sure a user matches an admin group (see :attr:`TINO_ADMIN_GROUPS <tino.config.TINO_ADMIN_GROUPS>`)
 7. Set the :attr:`TINO_OIDC_CLIENT_SECRET <tino.config.TINO_OIDC_CLIENT_SECRET>` to the **client secret**
 

--- a/tino/auth.py
+++ b/tino/auth.py
@@ -146,8 +146,21 @@ async def login(request: Request):
 @router.get('/oidc/callback', include_in_schema=False)
 async def callback(request: Request):
     '''Handle the OIDC callback, exchange code for tokens, and create a session.'''
-    token    = await oauth.oidc.authorize_access_token(request)
-    userinfo = await oauth.oidc.userinfo(token=token)
+    token = await oauth.oidc.authorize_access_token(request)
+
+    # Start from the ID-token claims, then enrich from the UserInfo endpoint
+    # when the provider exposes one (it is only RECOMMENDED by OIDC Discovery).
+    # Merging both keeps working whether the groups claim lands in the ID token
+    # (e.g. Keycloak mapper set to "add to ID token") or only at UserInfo
+    # (e.g. strict providers like Authelia) — reading just one drops the other.
+    userinfo = dict(token.get('userinfo') or {})
+    if oauth.oidc.server_metadata.get('userinfo_endpoint'):
+        try:
+            userinfo.update(await oauth.oidc.userinfo(token=token))
+        except Exception:  # pylint: disable=broad-exception-caught
+            # A missing/failing UserInfo endpoint must not break login when the
+            # ID token already carries the claims — degrade, don't 500.
+            logger.warning('UserInfo fetch failed; using ID-token claims', exc_info=True)
 
     if not userinfo:
         raise HTTPException(400, 'No user info in token response')


### PR DESCRIPTION
The userinfo endpoint is only *recommended*, but not *required* by OIDC. Thus there are OIDC providers which will provide only ID tokens, and no userinfo endpoint.

This change will make the userinfo endpoint optional. TINO will use the scopes from the ID token, then merge the userinfo endpoint scopes into it (if there's any).